### PR TITLE
Fix - send events only after Iframe load

### DIFF
--- a/src/modules/listeners/listeners.ts
+++ b/src/modules/listeners/listeners.ts
@@ -1,6 +1,7 @@
 import { EVENT_TYPES, MESSAGE_TYPES } from "./listeners.types";
 import * as eventsSender from "../events-sender/events-sender";
 import { STORAGE_NAMES } from "../storage-utils/storage-utils.types";
+import { showLoader } from "../loader/loader";
 
 // TODO: Remove all existing event listeners
 export function removeAllEventListeners() {}
@@ -43,4 +44,12 @@ export function initHostEventListeners() {
   );
 
   window.addEventListener(EVENT_TYPES.STORAGE, storageChanged);
+}
+
+// Subscriber event listeners
+export function initSubscriberEventListeners(iframeElement: HTMLElement) {
+  iframeElement.addEventListener("load", showLoader);
+
+  // Emptying events storage and posting all events
+  iframeElement.addEventListener("load", eventsSender.postAllEventMessages);
 }

--- a/src/modules/loader/loader.ts
+++ b/src/modules/loader/loader.ts
@@ -19,24 +19,18 @@ export function addLoader() {
   document.body.appendChild(loaderDiv);
 }
 
-export function addLoaderListener(iframeElement: HTMLElement) {
+export function showLoader() {
   const preloader = document.querySelector<HTMLElement>(".strigo-loader");
-
-  const fadeEffect = () => {
-    const interval = setInterval(() => {
-      if (!preloader.style.opacity) {
-        preloader.style.opacity = "1";
-      }
-      const opacity = parseFloat(preloader.style.opacity);
-      if (opacity > 0) {
-        preloader.style.opacity = (opacity - 0.1).toString();
-      } else {
-        preloader.style.pointerEvents = "none";
-        clearInterval(interval);
-      }
-    }, 200);
-  };
-
-  // Add listener to exercises div
-  iframeElement.addEventListener("load", fadeEffect);
+  const interval = setInterval(() => {
+    if (!preloader.style.opacity) {
+      preloader.style.opacity = "1";
+    }
+    const opacity = parseFloat(preloader.style.opacity);
+    if (opacity > 0) {
+      preloader.style.opacity = (opacity - 0.1).toString();
+    } else {
+      preloader.style.pointerEvents = "none";
+      clearInterval(interval);
+    }
+  }, 200);
 }

--- a/src/strigo/index.ts
+++ b/src/strigo/index.ts
@@ -85,7 +85,7 @@ export namespace Strigo {
       id: "exercises"
     });
 
-    addLoaderListener(exercisesIframe);
+    listeners.initSubscriberEventListeners(exercisesIframe);
 
     // Append original website Iframe
     documentTools.appendIFrame({
@@ -104,9 +104,6 @@ export namespace Strigo {
       currentUrl: configManager.getConfig().initSite.href,
       isPanelOpen: true
     });
-
-    // Emptying events storage and posting all events
-    eventsSender.postAllEventMessages();
 
     // Init the HOST event listeners
     listeners.initHostEventListeners();


### PR DESCRIPTION
## Context

We lost events that were sent before Meteor created templates.
Now we'll wait for the Iframe to load - this will create a better chance that the events will be received.

Out of scope - ACK mechanism with retires that will ensure events ingestion.
