### PR TITLE
[semver:patch] Add semver support to build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,20 @@ jobs:
             - node_modules
 
       - run:
+          name: Update package.json version (master branch only)
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              sudo curl -sSL -o /usr/local/bin/github-semver-release https://gist.githubusercontent.com/nir0s/ed262afd6a20d20af7be095e5004af9c/raw/c43c306f27905f05988f7399121103cd78fac047/semver-github-release.sh
+              source /usr/local/bin/github-semver-release
+
+              set_new_version
+              source semver.env
+              sed -i "s/\"version\": \"0.0.0\"/\"version\": \"$NEW_VERSION\"/g" package.json && cat package.json
+            fi
+
+      - run:
           name: Build extension
-          command: | 
+          command: |
             npm run build
             npm run purge
 
@@ -65,7 +77,11 @@ jobs:
 
       - run:
           name: Publish to GitHub
-          command: ghr -t $GITHUB_TOKEN -u strigo -delete latest ~/workspace/
+          command: |
+            sudo curl -sSL -o /usr/local/bin/github-semver-release https://gist.githubusercontent.com/nir0s/ed262afd6a20d20af7be095e5004af9c/raw/c43c306f27905f05988f7399121103cd78fac047/semver-github-release.sh
+            sudo chmod +x /usr/local/bin/github-semver-release
+
+            github-semver-release
 
 workflows:
   version: 2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdk",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Strigo In-App SDK",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Context

This adds support for using semver to automatically bump versions based on commit message prefixes (much like we do in the strigo-deploy-orb).

For now, it bash-hacks the hell out of things to get this done. If we like this solution, we can extract it somehow (maybe to our orb). It's important to note that we will now release both `latest` and a specific version at the same time. `latest` will be replaced, and a new version will be posted as well.

## Tests

- [x] Build fails when providing a bad semver bump type.
- [ ] Release is successful with correct version when providing a valid bump type.
- [x] The above happens only on master

@m1keil, your input will also be appreciated if you already had some mechanism in mind.