### PR TITLE
Add margin: unset

### DIFF
--- a/src/styles/strigo-widget.scss
+++ b/src/styles/strigo-widget.scss
@@ -25,6 +25,7 @@
   }
 
   .strigo-iframe {
+    margin: unset!important;
     position: relative;
     height: 100%;
     width: 100%;


### PR DESCRIPTION
## Context

Add `margin: unset!important` to the widget iframe to fix the weird margin in https://www.calibermind.com/

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/46085255/165219050-60a4073c-6d77-4de5-8085-9943bfdc8756.png)

### After
![image](https://user-images.githubusercontent.com/46085255/165219170-68a553fa-99fa-4985-8e43-a2187d7290cf.png)
