### PR TITLE
Fix shutdown bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,23 @@ window.addEventListener("strigo-opened", () => {
 
 ### Shutdown
 
-To shut the Strigo experience down, simply call:
+To shut down the Strigo academy, simply call:
 
 ```js
 window.Strigo.shutdown();
 ```
 
 The `sessionStorage` will be erased and the page will refresh.
+
+### Destroy
+
+To completely destroy the Strigo academy, use:
+
+```js
+window.Strigo.destroy();
+```
+
+The academy panel will be closed, `sessionStorage` and `localStorage` configuration will be erased.
 
 # Development
 

--- a/src/modules/config/config.ts
+++ b/src/modules/config/config.ts
@@ -14,8 +14,8 @@ export function init(initConfig: StrigoInitConfig): StrigoConfig {
   const config = getConfig();
 
   const initializedConfig = setupStorage<StrigoConfig>(STORAGE_TYPES.LOCAL_STORAGE, STORAGE_NAMES.STRIGO_CONFIG, {
-    ...initConfig,
     ...config,
+    ...initConfig,
   });
 
   return initializedConfig;

--- a/src/modules/listeners/listeners.ts
+++ b/src/modules/listeners/listeners.ts
@@ -26,39 +26,41 @@ export function storageChanged({ key, oldValue, newValue }): void {
   }
 }
 
+function onHostEventHandler(ev: MessageEvent<any>): void {
+  if (!ev || !ev.data) {
+    return;
+  }
+
+  switch (ev.data) {
+    case MESSAGE_TYPES.SHUTDOWN: {
+      window.Strigo?.shutdown();
+
+      break;
+    }
+
+    case MESSAGE_TYPES.CHALLENGE_SUCCESS: {
+      Logger.info('Challenge event success received');
+
+      if (sessionManager.getWidgetFlavor() === WIDGET_FLAVORS.OVERLAY) {
+        ovelayWidget.open();
+      }
+
+      break;
+    }
+
+    default: {
+      break;
+    }
+  }
+}
+
 // Host event listeners
 export function initHostEventListeners(): void {
-  window.addEventListener(
-    EVENT_TYPES.MESSAGE,
-    (ev) => {
-      if (!ev || !ev.data) {
-        return;
-      }
+  window.addEventListener(EVENT_TYPES.MESSAGE, onHostEventHandler, false);
+}
 
-      switch (ev.data) {
-        case MESSAGE_TYPES.SHUTDOWN: {
-          window.Strigo?.shutdown();
-
-          break;
-        }
-
-        case MESSAGE_TYPES.CHALLENGE_SUCCESS: {
-          Logger.info('Challenge event success received');
-
-          if (sessionManager.getWidgetFlavor() === WIDGET_FLAVORS.OVERLAY) {
-            ovelayWidget.open();
-          }
-
-          break;
-        }
-
-        default: {
-          break;
-        }
-      }
-    },
-    false
-  );
+export function removeHostEventListeners(): void {
+  window.removeEventListener(EVENT_TYPES.MESSAGE, onHostEventHandler);
 }
 
 export function initAcademyPlayerLoadedListeners(

--- a/src/modules/session/session.ts
+++ b/src/modules/session/session.ts
@@ -54,7 +54,3 @@ export function getSessionValue(key: keyof StrigoSession): any {
 export function clearSession(): void {
   clearStorage(STORAGE_TYPES.SESSION_STORAGE, STORAGE_NAMES.STRIGO_SESSION);
 }
-
-export function setPanelClosed(): void {
-  setSessionValue('isPanelOpen', false);
-}

--- a/src/modules/widgets/overlay.ts
+++ b/src/modules/widgets/overlay.ts
@@ -3,7 +3,6 @@ import * as documentTools from '../document/document';
 import * as urlTools from '../url/url';
 import * as listeners from '../listeners/listeners';
 import * as configManager from '../config/config';
-import * as sessionManager from '../session/session';
 import { SDK_TYPES } from '../../strigo/types';
 import { EVENT_TYPES } from '../listeners/listeners.types';
 
@@ -32,21 +31,27 @@ class OverlayWidget implements IOverlayWidget {
   }
 
   shutdown(): void {
-    Logger.info('overlay shutdown called');
+    this.removeEventListeners();
     documentTools.removeWidget();
-    sessionManager.setPanelClosed();
   }
 
   open(): void {
     documentTools.openWidget();
   }
 
+  private onStrigoEventHandler = (customEvent: CustomEvent): void => {
+    listeners.storageChanged(customEvent?.detail);
+  };
+
   private initEventListeners(academyPlayerFrame: HTMLIFrameElement): void {
     listeners.initAcademyPlayerLoadedListeners(academyPlayerFrame, makeOverlayWidgetVisible);
     listeners.initHostEventListeners();
-    window.addEventListener(EVENT_TYPES.OVERLAY_WIDGET_EVENT, (customEvent: CustomEvent) => {
-      listeners.storageChanged(customEvent?.detail);
-    });
+    window.addEventListener(EVENT_TYPES.OVERLAY_WIDGET_EVENT, this.onStrigoEventHandler);
+  }
+
+  private removeEventListeners(): void {
+    listeners.removeHostEventListeners();
+    window.removeEventListener(EVENT_TYPES.OVERLAY_WIDGET_EVENT, this.onStrigoEventHandler);
   }
 }
 

--- a/src/strigo/types.ts
+++ b/src/strigo/types.ts
@@ -14,11 +14,19 @@ export enum SDK_TYPES {
   OVERLAY = 'OVERLAY',
 }
 
+export interface SdkConfig {
+  initialized?: boolean;
+  configured?: boolean;
+  isOpen?: boolean;
+  sdkType?: SDK_TYPES;
+}
+
 export interface IStrigoSDK {
   init: () => void;
   setup: (data?: SDKSetupData) => Promise<void>;
   open: () => void;
   shutdown: () => void;
+  destroy: () => void;
   sendEvent: (eventName: string) => void;
 }
 


### PR DESCRIPTION
## Context

1. Remove event listeners on panel close, which is important especially for overlay widget where the widget can be opened and closed multiple times, and that resulted in multiple event listeners created.
2. Add destroy function to SDK to allow clean the configuration and SDK state completely.
3. Merge-overwrite stored init config in local storage by the data provided from SDK init function

## Tests

- [x] Open, refresh, close overlay academy
- [x] Open, refresh, close iframe academy
- [x] Multiple open close of overlay academy
- [x] Open overlay academy, change the widget type to iframe in the script params, refresh the page.
- [x] Destroy academy
