### PR TITLE
Add build to extension dir

### DIFF
--- a/esbuild-dev.js
+++ b/esbuild-dev.js
@@ -3,7 +3,8 @@ import esbuild from 'esbuild';
 import { sassPlugin } from 'esbuild-sass-plugin';
 import serve, { error, log } from 'create-serve';
 
-const OUT_DIR = 'dist/development';
+const LOCAL_OUT_DIR = 'dist/development';
+const EXTENSION_OUT_DIR = '../strigo-academy-chrome-extension/scripts';
 
 // Generate CSS/JS Builds
 esbuild
@@ -17,7 +18,7 @@ esbuild
       'src/strigo.sdk.ts',
     ],
     platform: 'browser',
-    outdir: OUT_DIR,
+    outdir: process.env.EXTENSION ? EXTENSION_OUT_DIR : LOCAL_OUT_DIR,
     bundle: true,
     plugins: [sassPlugin()],
     define: {
@@ -38,6 +39,6 @@ esbuild
 
 serve.start({
   port: process.env.SDK_HOSTING_PORT || 7000,
-  root: OUT_DIR,
+  root: process.env.EXTENSION ? EXTENSION_OUT_DIR : LOCAL_OUT_DIR,
   live: true,
 });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "node esbuild.js",
     "start": "node esbuild-dev.js -w",
+    "start:extension": "EXTENSION=true node esbuild-dev.js -w",
     "purge": "node purge-jsdelivr",
     "lint": "eslint --cache src",
     "lint:ci": "eslint --config .eslintrc.ci.cjs src"


### PR DESCRIPTION
## Context

Very hard to work with the SDK on multiple sites ATM.
This will make one step easier and will provide hot reload + copy compiled sdk to extension.
However - we still need to reload the extension for chrome's extension's menu - for it to work
