### PR TITLE
Show academy-hat until rendered

### DIFF
--- a/src/modules/document/document.ts
+++ b/src/modules/document/document.ts
@@ -127,7 +127,7 @@ export function openWidget(): void {
   academyHat.classList.remove('slide-in');
 }
 
-export function collapseWidget(): void {
+function collapse(): void {
   const widget = document.getElementById('strigo-widget');
   widget.classList.remove('slide-in');
   widget.classList.remove('loaded');
@@ -137,6 +137,12 @@ export function collapseWidget(): void {
 
   const academyHat = document.getElementById('strigo-academy-hat');
   academyHat.classList.add('slide-in');
+}
+
+export function collapseWidget(): void {
+  sessionManager.setSessionValue('shouldPanelBeOpen', false);
+
+  collapse();
 }
 
 const navigationObserver = function (pageMutations): void {
@@ -167,7 +173,7 @@ export function toggleWidget(): void {
   if (shouldPanelBeOpen) {
     openWidget();
   } else {
-    collapseWidget();
+    collapse();
   }
 }
 
@@ -219,7 +225,7 @@ export function createWidget(url: string): HTMLIFrameElement {
   if (shouldPanelBeOpen) {
     openWidget();
   } else {
-    collapseWidget();
+    collapse();
   }
 
   return strigoExercisesIframe;

--- a/src/modules/listeners/listeners.ts
+++ b/src/modules/listeners/listeners.ts
@@ -1,6 +1,6 @@
 import * as sessionManager from '../session/session';
 import * as configManager from '../config/config';
-import ovelayWidget from '../widgets/overlay';
+import overlayWidget from '../widgets/overlay';
 import { Logger } from '../../services/logger';
 import { WidgetFlavors } from '../widgets/widget.types';
 
@@ -16,7 +16,7 @@ function onHostEventHandler(ev: MessageEvent<any>): void {
       Logger.info('Panel move message received');
 
       if (sessionManager.getWidgetFlavor() === WidgetFlavors.OVERLAY) {
-        ovelayWidget.move();
+        overlayWidget.move();
       }
 
       break;
@@ -40,8 +40,15 @@ function onHostEventHandler(ev: MessageEvent<any>): void {
       Logger.info('Challenge event success received');
 
       if (sessionManager.getWidgetFlavor() === WidgetFlavors.OVERLAY) {
-        ovelayWidget.open();
+        overlayWidget.open();
       }
+
+      break;
+    }
+
+    case MessageTypes.RENDERED: {
+      Logger.info('Panel rendered message received');
+      window.Strigo?.expandPanel();
 
       break;
     }

--- a/src/modules/widgets/overlay.ts
+++ b/src/modules/widgets/overlay.ts
@@ -14,7 +14,7 @@ import { IOverlayWidget } from './widget.types';
 const MINIMUM_WIDTH = 342;
 
 function postDockableStateToStrigo(): void {
-  Logger.info('Posting dockable state to Strigo...');
+  Logger.info('Posting dockable state to Strigo', {});
   const dockingSide = configManager.getConfigValue('dockingSide');
   const strigoIframe = document.getElementById('strigo-exercises') as HTMLIFrameElement;
   strigoIframe.contentWindow.postMessage({ dockable: true, dockingSide }, '*');
@@ -114,7 +114,7 @@ class OverlayWidget implements IOverlayWidget {
 
   collapse(): void {
     Logger.info('overlay collapse called');
-    documentTools.toggleWidget();
+    documentTools.collapseWidget();
   }
 
   open(): void {

--- a/src/strigo/index.ts
+++ b/src/strigo/index.ts
@@ -150,6 +150,10 @@ class StrigoSDK implements IStrigoSDK {
 
       if (openWidget) {
         this.open();
+
+        // Collapse the panel so it would open when fully loaded
+        sessionManager.setSessionValue('shouldPanelBeOpen', false);
+        this.collapse();
       }
     } catch (err) {
       Logger.error('Could not setup SDK', { err });
@@ -189,6 +193,14 @@ class StrigoSDK implements IStrigoSDK {
     } catch (err) {
       Logger.error('Could not open academy panel', { err });
     }
+  }
+
+  expandPanel(): void {
+    Logger.info('Expanding academy panel');
+    const config = configManager.getLocalStorageConfig();
+
+    const widget = widgetFactory.getWidget(config.selectedWidgetFlavor);
+    widget.open();
   }
 
   collapse(): void {

--- a/src/strigo/types.ts
+++ b/src/strigo/types.ts
@@ -25,6 +25,7 @@ export interface IStrigoSDK {
   init: () => void;
   setup: (data?: SDKSetupData) => Promise<void>;
   open: () => void;
+  expandPanel: () => void;
   collapse?: () => void;
   shutdown: () => void;
   destroy: () => void;

--- a/src/styles/strigo-academy-hat.scss
+++ b/src/styles/strigo-academy-hat.scss
@@ -7,16 +7,14 @@
   position: fixed;
   top: 50%;
   right: 0;
-  width: 24px;
-  height: 28px;
+  width: 32px;
+  height: 36px;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
 
-  border: 1px solid #edf0f3;
-  border-right: none;
-  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2), 0px 8px 24px rgba(0, 0, 0, 0.14);
+  box-shadow: 0px 2px 1px rgb(0 0 0 / 12%), 0px 5px 8px rgb(0 0 0 / 26%);
   border-radius: 8px 0px 0px 8px;
 
   background-color: var(--customizable-hat-bg-color);
@@ -57,8 +55,8 @@
   }
 
   .strigo-academy-hat-icon {
-    width: 13px;
-    padding-bottom: 2px;
+    width: 16px;
+    padding-top: 1px;
     fill: var(--customizable-hat-text-color);
   }
 }


### PR DESCRIPTION
## Context

SDK Setup triggers the academy-hat. After strigo-app sends "rendered" message, the panel expands.

New and amazing loading experience. 

The next PR will be to change the academy hat to a loader.

## Tests

- [X] Reloaded page 

## Screenshots

https://user-images.githubusercontent.com/44494570/197502574-e6a1898f-f65d-46c7-ab2f-fcb13a7a1f59.mov



